### PR TITLE
Update test-summary/action to v2.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
     - run: pytest ${{ inputs.options }} --junit-xml=.test_report.xml ${{ inputs.paths }}
       shell: bash
 
-    - uses: test-summary/action@v1
+    - uses: test-summary/action@v2.1
       with:
         paths: .test_report.xml
         output: ${{ inputs.output }} 


### PR DESCRIPTION
Updated `test-summary/action` to version 2.1 so that the node.js 12 error message disappears. 
closes #7 